### PR TITLE
Update hosting-dats-from-a-server.html

### DIFF
--- a/guides/hosting-dats-from-a-server.html
+++ b/guides/hosting-dats-from-a-server.html
@@ -19,9 +19,9 @@
       <pre><code>
       npm install -g dat-next lil-pids add-to-systemd
       mkdir ~/dats
-      echo "dat clone dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93/ \
+      echo "dat dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93/ \
         ~/dats/datprotocol \
-        --upload --quiet" > ~/dats/services
+        --quiet" > ~/dats/services
       sudo add-to-systemd dat-lil-pids $(which lil-pids) ~/dats/services ~/dats/pids
       sudo systemctl start dat-lil-pids
       </pre></code>
@@ -74,9 +74,9 @@
       <p>Use an editor to write to <strong>~/dats/services</strong>:</p>
 
       <pre><code>
-      dat clone dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93/ \
+      dat dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93/ \
         ~/dats/datprotocol \
-        --upload --quiet
+        --quiet
       </code></pre>
 
       <p>To start the commands, we run:</p>


### PR DESCRIPTION
After this PR https://github.com/joehand/dat-next/pull/95, we can use the `dat <key> <dir>` as shorthand for `dat clone <key> <dir> --upload` 