### PR TITLE
Reorganize the frontpage, add datproject link

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,34 +8,18 @@
     <div class="content">
       <h1>Decentralized Archive Transport</h1>
       <h2>The Dat Protocol</h2>
-      <p>Dat is a fast, versioned, secure files protocol.</p>
+      <p>Dat is a new p2p hypermedia protocol. It provides public-key- &amp; sha256-addressed file archives which can be synced securely and browsed on-demand. Dat supports streaming updates and partial on-demand replication, and has plans for versioned URLs and efficient compaction.</p>
       <table>
         <tr><th>Fast</th><td>Archives sync from multiple sources at once.</td></tr>
+        <tr><th>Secure</th><td>Updates are signed, SHAed, and forced to be distributed unformly.</td></tr>
         <tr><th>Resilient</th><td>Archives can change hosts without changing their URLs.</td></tr>
-        <tr><th>Versioned</th><td>Changes are written to a referenceable log.</td></tr>
-        <tr><th>Secure</th><td>Updates are signed, checksummed, and forced to be distributed unformly.</td></tr>
-        <tr><th>P2P</th><td>Any device can be a host.</td></tr>
+        <tr><th>Versioned</th><td>Changes are written to an append-only log.</td></tr>
+        <tr><th>Decentralized</th><td>Any device can host any archive.</td></tr>
       </table>
-      <p>
-        Dat uses <a href="https://en.wikipedia.org/wiki/Rabin_fingerprint">rabin file-chunking<a/> and append-only feeds verified by <a href="https://en.wikipedia.org/wiki/Merkle_tree">merkle trees</a> to securely distribute mutable files with "live" update-pushing through a peer-to-peer network.
-        Peers are discovered using multiple overlapping networks (DHT, DNS, mUDP) and contacted via TCP or UTP.
-      </p>
-      <p>
-        Archives are identified by <a href="https://ed25519.cr.yp.to/">ed25519 public-keys</a> encoded as 64-character hex strings, making the URLs hostless and globally unique.
-        The site you are currently viewing is served at <a href="dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93/"><code>dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93/</code></a>.
-      </p>
-      <p>
-        Dat generalizes concepts from <a href="https://www.certificate-transparency.org/">certificate transparency</a> to provide its security guarantees.
-        All updates are written to a flattened merkle-tree (the feed) which is signed by the identifying public-key.
-        Data-feeds are distributed uniformly to all peers, and authors are unable to split the change history or serve alternative versions of an archive without detection.
-      </p>
-      <p>&raquo; Join us in #dat on freenode.</p>
-      <p>&raquo; <a href="https://github.com/datprotocol/website/issues">File issues for this website here</a>.</p>
-
-      <br>
+      <p>Dat is funded by grants by the Knight and Sloan Foundations. <a href="https://datproject.org">Learn more at the Dat Project</a>.</p>
+      <p>&raquo; Join us in #dat on freenode. &raquo; <a href="https://github.com/datprotocol/website/issues">File issues for this website here</a>.</p>
 
       <h2>Documentation</h2>
-
       <section>
         <h3><a href="/spec.html">Dat Specification</a></h3>
         <p><em>Draft, in progress</em>. A complete specification of the Dat protocol.</p>
@@ -47,10 +31,7 @@
         <p>Use the Dat CLI and a process-manager to rehost archives from a VPS.</p>
       </section>
 
-      <br>
-
       <h2>Applications</h2>
-
       <section>
         <h3><a href="https://github.com/datproject/dat">Dat Command-line</a></h3>
         <p>Sync and share folders from the command-line.</p>
@@ -62,7 +43,22 @@
         <p>An experimental P2P browser, which uses Dat as an alternative to HTTP.</p>
       </section>
 
-      <br>
+      <h2>About</h2>
+      <div>
+        <p>
+          Dat uses <a href="https://en.wikipedia.org/wiki/Rabin_fingerprint">rabin file-chunking<a/> and append-only feeds verified by <a href="https://en.wikipedia.org/wiki/Merkle_tree">merkle trees</a> to securely distribute mutable files with "live" update-pushing through a peer-to-peer network.
+          Peers are discovered using multiple overlapping networks (DHT, DNS, mUDP) and contacted via TCP or UTP.
+        </p>
+        <p>
+          Archives are identified by <a href="https://ed25519.cr.yp.to/">ed25519 public-keys</a> or sha256 hashes encoded as 64-character hex strings, making the URLs hostless and globally unique.
+          The site you are currently viewing is served at <a href="dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93/"><code>dat://ff34725120b2f3c5bd5028e4f61d14a45a22af48a7b12126d5d588becde88a93/</code></a>.
+        </p>
+        <p>
+          Dat generalizes concepts from <a href="https://www.certificate-transparency.org/">certificate transparency</a> to provide its security guarantees.
+          All updates are written to a flattened merkle-tree (the feed) which is signed by the identifying public-key.
+          Data-feeds are distributed uniformly to all peers, and authors are unable to split the change history or serve alternative versions of an archive without detection.
+        </p>
+      </div>
 
       <h2>Modules</h2>
       <p>Dat is authored in Javascript, and is split into reusable, self-contained modules. The main modules are:</p>


### PR DESCRIPTION
Help add some clarity by putting more overview up top, and the about section lower. Also add a link to the datproject.org site.